### PR TITLE
Interfaz Kanban para gestión de candidatos

### DIFF
--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -4,5 +4,10 @@ module.exports = {
     '^.+\\.tsx?$': 'ts-jest',
   },
   testRegex: '(/tests/.*|(\\.|/)(test|spec))\\.tsx?$',
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/src/setupTests.ts'],
+  moduleNameMapper: {
+    '\\.(css|less|scss|sass)$': '<rootDir>/src/tests/styleMock.js',
+  },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
 };

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,6 +21,9 @@
         "react-scripts": "5.0.1",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
+      },
+      "devDependencies": {
+        "ts-jest": "^27.1.5"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -5606,6 +5609,19 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stable-stringify": "2.x"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/bser": {
@@ -12296,6 +12312,13 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/makeerror": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
@@ -16736,6 +16759,50 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
+    },
+    "node_modules/ts-jest": {
+      "version": "27.1.5",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-27.1.5.tgz",
+      "integrity": "sha512-Xv6jBQPoBEvBq/5i2TeSG9tt/nqkbpcurrEG1b+2yfBrcJelOZF9Ml6dmyMh7bcW9JyFbRYpR5rxROSlBLTZHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bs-logger": "0.x",
+        "fast-json-stable-stringify": "2.x",
+        "jest-util": "^27.0.0",
+        "json5": "2.x",
+        "lodash.memoize": "4.x",
+        "make-error": "1.x",
+        "semver": "7.x",
+        "yargs-parser": "20.x"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0-beta.0 <8",
+        "@types/jest": "^27.0.0",
+        "babel-jest": ">=27.0.0 <28",
+        "jest": "^27.0.0",
+        "typescript": ">=3.8 <5.0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@types/jest": {
+          "optional": true
+        },
+        "babel-jest": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        }
+      }
     },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,5 +40,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "ts-jest": "^27.1.5"
   }
 }

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,38 +1,200 @@
-.App {
+.position-page {
+  background: #f5f7fb;
+  color: #172033;
+  min-height: 100vh;
+  padding: 32px;
+}
+
+.position-header {
+  align-items: center;
+  display: flex;
+  gap: 16px;
+  margin: 0 auto 24px;
+  max-width: 1180px;
+}
+
+.back-link {
+  align-items: center;
+  background: #ffffff;
+  border: 1px solid #d9e1ee;
+  border-radius: 8px;
+  box-shadow: 0 8px 20px rgba(23, 32, 51, 0.06);
+  color: #25314a;
+  display: inline-flex;
+  font-size: 24px;
+  font-weight: 700;
+  height: 44px;
+  justify-content: center;
+  text-decoration: none;
+  width: 44px;
+}
+
+.back-link:hover {
+  border-color: #9aa8bd;
+}
+
+.eyebrow {
+  color: #63708a;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0;
+  margin: 0 0 4px;
+  text-transform: uppercase;
+}
+
+.position-header h1 {
+  font-size: 32px;
+  line-height: 1.2;
+  margin: 0;
+}
+
+.status-message,
+.loading-state {
+  background: #ffffff;
+  border: 1px solid #d9e1ee;
+  border-radius: 8px;
+  margin: 0 auto 18px;
+  max-width: 1180px;
+  padding: 14px 16px;
+}
+
+.status-message {
+  color: #8a4b08;
+}
+
+.loading-state {
+  color: #63708a;
+}
+
+.kanban-board {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  margin: 0 auto;
+  max-width: 1180px;
+}
+
+.kanban-column {
+  background: #eaf0f8;
+  border: 1px solid #d9e1ee;
+  border-radius: 8px;
+  min-height: 520px;
+  padding: 14px;
+}
+
+.column-header {
+  align-items: center;
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+  margin-bottom: 14px;
+}
+
+.column-header h2 {
+  font-size: 16px;
+  line-height: 1.25;
+  margin: 0;
+}
+
+.column-header span {
+  align-items: center;
+  background: #ffffff;
+  border: 1px solid #d9e1ee;
+  border-radius: 999px;
+  color: #41506a;
+  display: inline-flex;
+  font-size: 13px;
+  font-weight: 700;
+  height: 26px;
+  justify-content: center;
+  min-width: 26px;
+  padding: 0 8px;
+}
+
+.candidate-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 430px;
+}
+
+.candidate-card {
+  background: #ffffff;
+  border: 1px solid #d9e1ee;
+  border-radius: 8px;
+  box-shadow: 0 10px 22px rgba(23, 32, 51, 0.08);
+  cursor: grab;
+  padding: 16px;
+  transition: box-shadow 160ms ease, transform 160ms ease;
+}
+
+.candidate-card:active {
+  cursor: grabbing;
+}
+
+.candidate-card:hover {
+  box-shadow: 0 14px 28px rgba(23, 32, 51, 0.12);
+  transform: translateY(-2px);
+}
+
+.candidate-card h3 {
+  font-size: 16px;
+  line-height: 1.35;
+  margin: 0 0 14px;
+  overflow-wrap: anywhere;
+}
+
+.candidate-card p {
+  align-items: center;
+  color: #63708a;
+  display: flex;
+  font-size: 13px;
+  justify-content: space-between;
+  margin: 0;
+}
+
+.candidate-card strong {
+  background: #edf7f2;
+  border: 1px solid #b8dbc8;
+  border-radius: 999px;
+  color: #17623d;
+  font-size: 14px;
+  min-width: 42px;
+  padding: 4px 8px;
   text-align: center;
 }
 
-.App-logo {
-  height: 40vmin;
-  pointer-events: none;
+.empty-column {
+  border: 1px dashed #bdc8d8;
+  border-radius: 8px;
+  color: #63708a;
+  margin: 0;
+  padding: 18px;
+  text-align: center;
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  .App-logo {
-    animation: App-logo-spin infinite 20s linear;
+@media (max-width: 720px) {
+  .position-page {
+    padding: 20px;
   }
-}
 
-.App-header {
-  background-color: #282c34;
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
-}
-
-.App-link {
-  color: #61dafb;
-}
-
-@keyframes App-logo-spin {
-  from {
-    transform: rotate(0deg);
+  .position-header {
+    align-items: flex-start;
   }
-  to {
-    transform: rotate(360deg);
+
+  .position-header h1 {
+    font-size: 24px;
+  }
+
+  .kanban-board {
+    grid-template-columns: 1fr;
+  }
+
+  .kanban-column {
+    min-height: auto;
+  }
+
+  .candidate-list {
+    min-height: 120px;
   }
 }

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -164,6 +164,34 @@
   text-align: center;
 }
 
+.move-actions {
+  border-top: 1px solid #eef2f7;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 14px;
+  padding-top: 12px;
+}
+
+.move-actions button {
+  background: #f6f8fb;
+  border: 1px solid #cfd8e6;
+  border-radius: 8px;
+  color: #25314a;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.2;
+  padding: 8px 10px;
+}
+
+.move-actions button:hover,
+.move-actions button:focus-visible {
+  background: #ffffff;
+  border-color: #8ea0b8;
+  outline: none;
+}
+
 .empty-column {
   border: 1px dashed #bdc8d8;
   border-radius: 8px;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -164,6 +164,11 @@ function App() {
     }, {});
   }, [candidates, steps]);
 
+  function getNextStep(currentStep: InterviewStep) {
+    const currentIndex = steps.findIndex((step) => step.id === currentStep.id);
+    return steps[currentIndex + 1] || steps[currentIndex - 1];
+  }
+
   async function moveCandidate(candidateId: string, targetStep: InterviewStep) {
     const candidate = candidates.find((item) => item.boardId === candidateId);
 
@@ -171,7 +176,7 @@ function App() {
       return;
     }
 
-    const previousCandidates = candidates;
+    const previousStep = candidate.currentInterviewStep;
 
     setCandidates((currentCandidates) =>
       currentCandidates.map((item) =>
@@ -200,7 +205,14 @@ function App() {
 
       setError('');
     } catch {
-      setCandidates(previousCandidates);
+      setCandidates((currentCandidates) =>
+        currentCandidates.map((item) =>
+          item.boardId === candidateId &&
+          String(item.currentInterviewStep) === String(targetStep.id)
+            ? { ...item, currentInterviewStep: previousStep }
+            : item,
+        ),
+      );
       setError('No se pudo actualizar la etapa del candidato. Intentalo de nuevo.');
     }
   }
@@ -245,6 +257,7 @@ function App() {
               <article
                 className="kanban-column"
                 key={step.id}
+                aria-label={`Fase ${step.name}`}
                 onDragOver={(event) => event.preventDefault()}
                 onDrop={(event) => handleDrop(event, step)}
               >
@@ -262,18 +275,46 @@ function App() {
                         className="candidate-card"
                         draggable
                         key={candidate.boardId}
+                        role="button"
+                        tabIndex={0}
+                        aria-grabbed={draggedCandidateId === candidate.boardId}
+                        aria-label={`${candidate.fullName}, puntuacion media ${candidate.averageScore.toFixed(1)}`}
                         onDragStart={(event) => {
                           setDraggedCandidateId(candidate.boardId);
                           event.dataTransfer.effectAllowed = 'move';
                           event.dataTransfer.setData('text/plain', candidate.boardId);
                         }}
                         onDragEnd={() => setDraggedCandidateId(null)}
+                        onKeyDown={(event) => {
+                          const nextStep = getNextStep(step);
+
+                          if ((event.key === 'Enter' || event.key === ' ') && nextStep) {
+                            event.preventDefault();
+                            moveCandidate(candidate.boardId, nextStep);
+                          }
+                        }}
                       >
                         <h3>{candidate.fullName}</h3>
                         <p>
                           <span>Puntuacion media</span>
                           <strong>{candidate.averageScore.toFixed(1)}</strong>
                         </p>
+                        <div className="move-actions" aria-label={`Mover a ${candidate.fullName}`}>
+                          {steps
+                            .filter((targetStep) => targetStep.id !== step.id)
+                            .map((targetStep) => (
+                              <button
+                                type="button"
+                                key={targetStep.id}
+                                onClick={(event) => {
+                                  event.stopPropagation();
+                                  moveCandidate(candidate.boardId, targetStep);
+                                }}
+                              >
+                                Mover a {targetStep.name}
+                              </button>
+                            ))}
+                        </div>
                       </div>
                     ))
                   )}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,25 +1,289 @@
-import React from 'react';
-import logo from './logo.svg';
+import React, { useEffect, useMemo, useState } from 'react';
 import './App.css';
 
-function App() {
+type InterviewStep = {
+  id: number;
+  name: string;
+  orderIndex: number;
+};
+
+type InterviewFlowResponse = {
+  positionName: string;
+  interviewFlow: {
+    interviewSteps: InterviewStep[];
+  };
+};
+
+type CandidateResponse = {
+  id?: number | string;
+  applicationId?: number | string;
+  candidateId?: number | string;
+  fullName: string;
+  currentInterviewStep: number | string;
+  averageScore: number;
+};
+
+type Candidate = CandidateResponse & {
+  boardId: string;
+};
+
+const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:3010';
+
+const fallbackFlow: InterviewFlowResponse = {
+  positionName: 'Senior backend engineer',
+  interviewFlow: {
+    interviewSteps: [
+      { id: 1, name: 'Initial Screening', orderIndex: 1 },
+      { id: 2, name: 'Technical Interview', orderIndex: 2 },
+      { id: 3, name: 'Manager Interview', orderIndex: 3 },
+    ],
+  },
+};
+
+const fallbackCandidates: CandidateResponse[] = [
+  {
+    id: 1,
+    applicationId: 1,
+    fullName: 'Jane Smith',
+    currentInterviewStep: 'Technical Interview',
+    averageScore: 4,
+  },
+  {
+    id: 2,
+    applicationId: 2,
+    fullName: 'Carlos Garcia',
+    currentInterviewStep: 'Initial Screening',
+    averageScore: 0,
+  },
+  {
+    id: 3,
+    applicationId: 3,
+    fullName: 'John Doe',
+    currentInterviewStep: 'Manager Interview',
+    averageScore: 5,
+  },
+];
+
+function getPositionId() {
+  const match = window.location.pathname.match(/positions\/([^/]+)/);
+  return match?.[1] || '1';
+}
+
+function getCandidateBoardId(candidate: CandidateResponse, index: number) {
+  return String(candidate.applicationId ?? candidate.id ?? candidate.candidateId ?? `candidate-${index}`);
+}
+
+function getCandidateApiId(candidate: Candidate) {
+  return candidate.applicationId ?? candidate.id ?? candidate.candidateId ?? candidate.boardId;
+}
+
+function candidateBelongsToStep(candidate: Candidate, step: InterviewStep) {
   return (
-    <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.tsx</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
+    String(candidate.currentInterviewStep) === String(step.id) ||
+    String(candidate.currentInterviewStep).toLowerCase() === step.name.toLowerCase()
+  );
+}
+
+function App() {
+  const [positionName, setPositionName] = useState('');
+  const [steps, setSteps] = useState<InterviewStep[]>([]);
+  const [candidates, setCandidates] = useState<Candidate[]>([]);
+  const [draggedCandidateId, setDraggedCandidateId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const positionId = getPositionId();
+
+  useEffect(() => {
+    let mounted = true;
+
+    async function loadPositionBoard() {
+      setLoading(true);
+      setError('');
+
+      try {
+        const [flowResponse, candidatesResponse] = await Promise.all([
+          fetch(`${API_URL}/positions/${positionId}/interviewFlow`),
+          fetch(`${API_URL}/positions/${positionId}/candidates`),
+        ]);
+
+        if (!flowResponse.ok || !candidatesResponse.ok) {
+          throw new Error('No se pudo conectar con la API');
+        }
+
+        const flowData: InterviewFlowResponse = await flowResponse.json();
+        const candidatesData: CandidateResponse[] = await candidatesResponse.json();
+
+        if (!mounted) {
+          return;
+        }
+
+        setPositionName(flowData.positionName);
+        setSteps(
+          [...flowData.interviewFlow.interviewSteps].sort(
+            (a, b) => a.orderIndex - b.orderIndex || a.id - b.id,
+          ),
+        );
+        setCandidates(
+          candidatesData.map((candidate, index) => ({
+            ...candidate,
+            boardId: getCandidateBoardId(candidate, index),
+          })),
+        );
+      } catch {
+        if (!mounted) {
+          return;
+        }
+
+        setError('Mostrando datos de ejemplo porque la API no esta disponible.');
+        setPositionName(fallbackFlow.positionName);
+        setSteps(fallbackFlow.interviewFlow.interviewSteps);
+        setCandidates(
+          fallbackCandidates.map((candidate, index) => ({
+            ...candidate,
+            boardId: getCandidateBoardId(candidate, index),
+          })),
+        );
+      } finally {
+        if (mounted) {
+          setLoading(false);
+        }
+      }
+    }
+
+    loadPositionBoard();
+
+    return () => {
+      mounted = false;
+    };
+  }, [positionId]);
+
+  const candidatesByStep = useMemo(() => {
+    return steps.reduce<Record<number, Candidate[]>>((groups, step) => {
+      groups[step.id] = candidates.filter((candidate) => candidateBelongsToStep(candidate, step));
+      return groups;
+    }, {});
+  }, [candidates, steps]);
+
+  async function moveCandidate(candidateId: string, targetStep: InterviewStep) {
+    const candidate = candidates.find((item) => item.boardId === candidateId);
+
+    if (!candidate || candidateBelongsToStep(candidate, targetStep)) {
+      return;
+    }
+
+    const previousCandidates = candidates;
+
+    setCandidates((currentCandidates) =>
+      currentCandidates.map((item) =>
+        item.boardId === candidateId
+          ? { ...item, currentInterviewStep: targetStep.id }
+          : item,
+      ),
+    );
+
+    try {
+      const response = await fetch(`${API_URL}/candidates/${getCandidateApiId(candidate)}/stage`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          applicationId: getCandidateApiId(candidate),
+          currentInterviewStep: targetStep.id,
+          new_interview_step: targetStep.id,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error('No se pudo actualizar la etapa');
+      }
+
+      setError('');
+    } catch {
+      setCandidates(previousCandidates);
+      setError('No se pudo actualizar la etapa del candidato. Intentalo de nuevo.');
+    }
+  }
+
+  function handleDrop(event: React.DragEvent<HTMLElement>, targetStep: InterviewStep) {
+    event.preventDefault();
+    const candidateId = draggedCandidateId || event.dataTransfer.getData('text/plain');
+
+    if (candidateId) {
+      moveCandidate(candidateId, targetStep);
+    }
+
+    setDraggedCandidateId(null);
+  }
+
+  return (
+    <main className="position-page">
+      <section className="position-header" aria-labelledby="position-title">
+        <a className="back-link" href="/positions" aria-label="Volver al listado de posiciones">
+          <span aria-hidden="true">←</span>
         </a>
-      </header>
-    </div>
+        <div>
+          <p className="eyebrow">Proceso de contratacion</p>
+          <h1 id="position-title">{positionName || 'Position'}</h1>
+        </div>
+      </section>
+
+      {error && (
+        <p className="status-message" role="status">
+          {error}
+        </p>
+      )}
+
+      {loading ? (
+        <div className="loading-state">Cargando candidatos...</div>
+      ) : (
+        <section className="kanban-board" aria-label="Candidatos por fase">
+          {steps.map((step) => {
+            const stepCandidates = candidatesByStep[step.id] || [];
+
+            return (
+              <article
+                className="kanban-column"
+                key={step.id}
+                onDragOver={(event) => event.preventDefault()}
+                onDrop={(event) => handleDrop(event, step)}
+              >
+                <header className="column-header">
+                  <h2>{step.name}</h2>
+                  <span>{stepCandidates.length}</span>
+                </header>
+
+                <div className="candidate-list">
+                  {stepCandidates.length === 0 ? (
+                    <p className="empty-column">Sin candidatos</p>
+                  ) : (
+                    stepCandidates.map((candidate) => (
+                      <div
+                        className="candidate-card"
+                        draggable
+                        key={candidate.boardId}
+                        onDragStart={(event) => {
+                          setDraggedCandidateId(candidate.boardId);
+                          event.dataTransfer.effectAllowed = 'move';
+                          event.dataTransfer.setData('text/plain', candidate.boardId);
+                        }}
+                        onDragEnd={() => setDraggedCandidateId(null)}
+                      >
+                        <h3>{candidate.fullName}</h3>
+                        <p>
+                          <span>Puntuacion media</span>
+                          <strong>{candidate.averageScore.toFixed(1)}</strong>
+                        </p>
+                      </div>
+                    ))
+                  )}
+                </div>
+              </article>
+            );
+          })}
+        </section>
+      )}
+    </main>
   );
 }
 

--- a/frontend/src/tests/App.test.tsx
+++ b/frontend/src/tests/App.test.tsx
@@ -1,35 +1,54 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import App from '../App';
 
-const mockFetch = jest.fn((url: string) => {
-  if (url.includes('/interviewFlow')) {
-    return Promise.resolve({
-      ok: true,
-      json: () =>
-        Promise.resolve({
-          positionName: 'Senior backend engineer',
-          interviewFlow: {
-            interviewSteps: [{ id: 1, name: 'Initial Screening', orderIndex: 1 }],
-          },
-        }),
-    });
-  }
+const flowResponse = {
+  positionName: 'Senior backend engineer',
+  interviewFlow: {
+    interviewSteps: [
+      { id: 1, name: 'Initial Screening', orderIndex: 1 },
+      { id: 2, name: 'Technical Interview', orderIndex: 2 },
+    ],
+  },
+};
 
-  return Promise.resolve({
-    ok: true,
-    json: () =>
-      Promise.resolve([
-        {
-          id: 1,
-          applicationId: 1,
-          fullName: 'Jane Smith',
-          currentInterviewStep: 'Initial Screening',
-          averageScore: 4,
-        },
-      ]),
+const candidatesResponse = [
+  {
+    id: 1,
+    applicationId: 1,
+    fullName: 'Jane Smith',
+    currentInterviewStep: 'Initial Screening',
+    averageScore: 4,
+  },
+];
+
+const originalFetch = global.fetch;
+const mockFetch = jest.fn();
+
+function createFetchResponse(body: unknown, ok = true) {
+  return {
+    ok,
+    json: () => Promise.resolve(body),
+  };
+}
+
+function mockInitialRequests(putResponse: Promise<unknown>) {
+  mockFetch.mockImplementation((url: string) => {
+    if (url.includes('/interviewFlow')) {
+      return Promise.resolve(createFetchResponse(flowResponse));
+    }
+
+    if (url.includes('/positions/1/candidates')) {
+      return Promise.resolve(createFetchResponse(candidatesResponse));
+    }
+
+    if (url.includes('/candidates/1/stage')) {
+      return putResponse;
+    }
+
+    return Promise.reject(new Error(`Unexpected request: ${url}`));
   });
-});
+}
 
 beforeEach(() => {
   window.history.pushState({}, '', '/positions/1');
@@ -37,12 +56,63 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  mockFetch.mockClear();
+  mockFetch.mockReset();
+  global.fetch = originalFetch;
 });
 
 test('renders the position board header', async () => {
+  mockInitialRequests(Promise.resolve(createFetchResponse({ message: 'ok' })));
+
   render(<App />);
+
   expect(screen.getByText(/proceso de contratacion/i)).toBeInTheDocument();
   expect(screen.getByLabelText(/volver al listado de posiciones/i)).toBeInTheDocument();
   expect(await screen.findByText(/senior backend engineer/i)).toBeInTheDocument();
+});
+
+test('moves a candidate optimistically and keeps the new stage when the API succeeds', async () => {
+  let resolvePut: (value: unknown) => void = () => undefined;
+  const putResponse = new Promise((resolve) => {
+    resolvePut = resolve;
+  });
+  mockInitialRequests(putResponse);
+
+  render(<App />);
+
+  const initialColumn = await screen.findByLabelText(/fase initial screening/i);
+  expect(await within(initialColumn).findByText('Jane Smith')).toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole('button', { name: /mover a technical interview/i }));
+
+  expect(within(screen.getByLabelText(/fase technical interview/i)).getByText('Jane Smith')).toBeInTheDocument();
+
+  resolvePut(createFetchResponse({ message: 'Candidate stage updated successfully' }));
+
+  await waitFor(() =>
+    expect(within(screen.getByLabelText(/fase technical interview/i)).getByText('Jane Smith')).toBeInTheDocument(),
+  );
+});
+
+test('rolls back only the moved candidate when the API update fails', async () => {
+  let resolvePut: (value: unknown) => void = () => undefined;
+  const putResponse = new Promise((resolve) => {
+    resolvePut = resolve;
+  });
+  mockInitialRequests(putResponse);
+
+  render(<App />);
+
+  const initialColumn = await screen.findByLabelText(/fase initial screening/i);
+  expect(await within(initialColumn).findByText('Jane Smith')).toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole('button', { name: /mover a technical interview/i }));
+
+  expect(within(screen.getByLabelText(/fase technical interview/i)).getByText('Jane Smith')).toBeInTheDocument();
+
+  resolvePut(createFetchResponse({ message: 'error' }, false));
+
+  await waitFor(() =>
+    expect(within(screen.getByLabelText(/fase initial screening/i)).getByText('Jane Smith')).toBeInTheDocument(),
+  );
+  expect(screen.getByText(/no se pudo actualizar la etapa del candidato/i)).toBeInTheDocument();
 });

--- a/frontend/src/tests/App.test.tsx
+++ b/frontend/src/tests/App.test.tsx
@@ -2,8 +2,47 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import App from '../App';
 
-test('renders learn react link', () => {
+const mockFetch = jest.fn((url: string) => {
+  if (url.includes('/interviewFlow')) {
+    return Promise.resolve({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          positionName: 'Senior backend engineer',
+          interviewFlow: {
+            interviewSteps: [{ id: 1, name: 'Initial Screening', orderIndex: 1 }],
+          },
+        }),
+    });
+  }
+
+  return Promise.resolve({
+    ok: true,
+    json: () =>
+      Promise.resolve([
+        {
+          id: 1,
+          applicationId: 1,
+          fullName: 'Jane Smith',
+          currentInterviewStep: 'Initial Screening',
+          averageScore: 4,
+        },
+      ]),
+  });
+});
+
+beforeEach(() => {
+  window.history.pushState({}, '', '/positions/1');
+  global.fetch = mockFetch as jest.Mock;
+});
+
+afterEach(() => {
+  mockFetch.mockClear();
+});
+
+test('renders the position board header', async () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  expect(screen.getByText(/proceso de contratacion/i)).toBeInTheDocument();
+  expect(screen.getByLabelText(/volver al listado de posiciones/i)).toBeInTheDocument();
+  expect(await screen.findByText(/senior backend engineer/i)).toBeInTheDocument();
 });

--- a/frontend/src/tests/styleMock.js
+++ b/frontend/src/tests/styleMock.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/prompts/prompts-iniciales.md
+++ b/prompts/prompts-iniciales.md
@@ -1,0 +1,16 @@
+# Prompts iniciales
+
+## Prompt del ejercicio
+
+Realiza el ejercicio de frontend para crear la interfaz `position`: una pagina tipo kanban donde se visualicen y gestionen los candidatos de una posicion especifica.
+
+## Criterios implementados
+
+- Mostrar el titulo de la posicion en la parte superior.
+- Incluir una flecha de regreso al listado de posiciones.
+- Renderizar una columna por cada fase del proceso de contratacion.
+- Ubicar cada candidato en su fase actual.
+- Mostrar nombre completo y puntuacion media en cada tarjeta.
+- Permitir mover candidatos entre fases usando drag and drop.
+- Actualizar la fase con el endpoint `PUT /candidates/:id/stage`.
+- Adaptar el tablero a mobile mostrando las fases en vertical.


### PR DESCRIPTION
## Resumen

Implementa la página de detalle de una posición con una interfaz tipo Kanban para visualizar y gestionar candidatos por fase del proceso de contratación.

## Cambios principales

- Muestra el título de la posición y enlace de regreso al listado de posiciones.
- Carga las fases desde `GET /positions/:id/interviewFlow`.
- Carga los candidatos desde `GET /positions/:id/candidates`.
- Agrupa las tarjetas de candidatos por fase.
- Permite mover candidatos entre columnas con drag and drop.
- Actualiza la fase mediante `PUT /candidates/:id/stage`.
- Añade diseño responsive para móvil.
- Incluye `prompts/prompts-iniciales.md`.

## Verificación

- `npm test -- --runInBand`
- `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Biblia-en-Contexto: Spanish Bible study web application with chronological event exploration, exegesis tools, glossary, and resource library
  * Interview management kanban board with drag-and-drop candidate stage transitions and mobile responsiveness
  * LTI recruitment platform documentation with system design specifications and feature roadmap

* **Documentation**
  * Added product vision documents outlining application architecture, data models, and phased rollout plans

<!-- end of auto-generated comment: release notes by coderabbit.ai -->